### PR TITLE
Use mount options

### DIFF
--- a/workspace/src/github.com/previousnext/k8s-aws-efs/provision.go
+++ b/workspace/src/github.com/previousnext/k8s-aws-efs/provision.go
@@ -13,6 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// MountOptionAnnotation is the annotation on a PV object that specifies a
+// comma separated list of mount options
+const MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
+
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *efsProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
 	// This is a consistent naming pattern for provisioning our EFS objects.
@@ -33,6 +37,11 @@ func (p *efsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: id,
+			Annotations: map[string]string{
+				// https://kubernetes.io/docs/concepts/storage/persistent-volumes
+				// http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
+				MountOptionAnnotation: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2",
+			},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			// PersistentVolumeReclaimPolicy, AccessModes and Capacity are required fields.


### PR DESCRIPTION
#### What does this PR do?
 
Enables NFS 4.1 for PVC generated volumes.

#### How should this be manually tested?

* Deploy version "previousnext/k8s-aws-efs:2.0.0-1-gf45b121b"
* Provision a new EFS volume
* Check that its mounted with "vers=4.1"

#### Any background context you want to provide?
 
4.0 has issues on AWS

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)

N/A
 
#### Questions:

##### Does any external documentation require updating?

N/A

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

N/A