### PR TITLE
Moves CreateMount logic to goroutine

### DIFF
--- a/efsutils/efsutils.go
+++ b/efsutils/efsutils.go
@@ -1,7 +1,9 @@
 package efsutils
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,37 +40,71 @@ func Create(region, name string, subnets []string, securityGroup string, perform
 
 		// The filesystem is ready!
 		if *fs.LifeCycleState == efs.LifeCycleStateAvailable {
+			glog.Infof("FileSystem %s is ready", *fs.FileSystemId)
 			break
 		}
 
 		<-limiter
 	}
 
-	// Create the mount targets.
+	var wg sync.WaitGroup
+	// ResultChan, ErrorChan
+	resc, errc := make(chan string), make(chan error)
+
 	for _, subnet := range subnets {
-		_, err := CreateMount(client, *fs.FileSystemId, subnet, securityGroup)
-		if err != nil {
+		wg.Add(1)
+
+		// Create the mount targets.
+		go func(sn string) {
+			defer wg.Done()
+
+			_, err := CreateMount(client, *fs.FileSystemId, sn, securityGroup)
+			if err != nil {
+				errc <- err
+			} else {
+				for {
+					glog.Infof("Waiting for mount target to become ready: %s:%s", name, sn)
+
+					// Passing this back to the create function means that it will check if
+					// the mount target exists first.
+					// So it is safe for us to rerun this function to get the latest status.
+					target, err := CreateMount(client, *fs.FileSystemId, sn, securityGroup)
+					if err != nil {
+						msg := fmt.Sprintf("Failed to create filesystem: %s", err)
+						glog.Error(msg)
+						errc <- errors.New(msg)
+						break
+					}
+
+					// The filesystem is ready!
+					if *target.LifeCycleState == efs.LifeCycleStateAvailable {
+						glog.Infof("Mount point in subnet %s is available", sn)
+						resc <- fmt.Sprintf("[subnet: %s]", sn)
+						break
+					}
+
+					<-limiter
+				}
+			}
+		}(subnet)
+	}
+
+	// If any errors come through, exit early.
+	for i := 0; i < len(subnets); i++ {
+		select {
+		case res := <-resc:
+			fmt.Printf("Created mount point %s\n", res)
+		case err := <-errc:
+			glog.Errorf("Error creating mount point %s", err)
 			return "", err
 		}
-
-		for {
-			glog.Infof("Waiting for mount target to become ready: %s", name)
-
-			// Passing this back to the create function means that it will check if the mount target exists first.
-			// So it is safe for us to rerun this function to get the latest status.
-			target, err := CreateMount(client, *fs.FileSystemId, subnet, securityGroup)
-			if err != nil {
-				return "", fmt.Errorf("failed to create filesystem: %s", err)
-			}
-
-			// The filesystem is ready!
-			if *target.LifeCycleState == efs.LifeCycleStateAvailable {
-				break
-			}
-
-			<-limiter
-		}
 	}
+
+	// Wait for all subnets to be ready
+	wg.Wait()
+
+	close(resc)
+	close(errc)
 
 	return *fs.FileSystemId, nil
 }


### PR DESCRIPTION
#### What does this PR do?

Reduces EFS creation time by ~ 5 min (with 3 subnets) by asynchronously creating mount points.

#### How should this be manually tested?

Tail the logs of the `k8s-aws-efs` pod and watch subnets being created. Verify they were actually created via the AWS Console/CLI

#### Any background context you want to provide?

I started looking around for what #2 might refer to, noticed the mount creation was synchronous, and thought this would be an easy improvement. Also, I'm just learning Go, so I'm not positive this is the best way to go about it, particularly w/r/t future rate-limiting improvements.

#### What are the relevant tickets?

See above

#### Screenshots (if appropriate)
 
#### Questions:

##### Does any external documentation require updating?

No

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

No